### PR TITLE
remove visual-diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     "lint:lit": "lit-analyzer orgStructureGraph.js demo test",
     "start": "es-dev-server --app-index demo/index.html --node-resolve --dedupe --open --watch",
     "test": "npm run lint && npm run test:headless",
-    "test:diff": "mocha ./**/*.visual-diff.js -t 40000",
-    "test:diff:golden": "mocha ./**/*.visual-diff.js -t 40000 --golden",
-    "test:diff:golden:commit": "commit-goldens",
     "test:headless": "karma start",
     "test:headless:watch": "karma start --auto-watch=true --single-run=false",
     "test:sauce": "karma start karma.sauce.conf.js"
@@ -31,9 +28,9 @@
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@brightspace-ui/visual-diff": "^1",
     "@open-wc/testing": "^2",
     "@open-wc/testing-karma": "^3",
+    "@webcomponents/webcomponentsjs": "^2",
     "babel-eslint": "^10",
     "deepmerge": "^3",
     "es-dev-server": "^1",
@@ -44,12 +41,10 @@
     "eslint-plugin-sort-class-members": "^1",
     "frau-ci": "^1",
     "karma-sauce-launcher": "^2",
-    "lit-analyzer": "^1",
-    "puppeteer": "^5"
+    "lit-analyzer": "^1"
   },
   "dependencies": {
     "@brightspace-ui/core": "^1",
-    "@webcomponents/webcomponentsjs": "^2",
     "d3": "^6.2.0",
     "d3-hierarchy": "^2.0.0",
     "lit-element": "^2"


### PR DESCRIPTION
We're in the process of migrating all the visual-diff usages to use GitHub Actions. It doesn't look like visual-diff was ever actually run on this repo, so this removes it completely for now to get it off our list.

If you'd like to re-enable visual-diff down the road, the process is a lot easier now but you'll need to move things over to GitHub Actions. I can help you with that when the time comes.